### PR TITLE
Fixed typographical error, changed aquisition to acquisition in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The [Foursquare Platform](https://developer.foursquare.com) is a set of APIs tha
 
 This project contains the open source **Grails Foursquare Authenticate Plugin** that allows you to integrate the Foursquare Authenticate on a website/app powered by [Grails](http://grails.org).
 
-I created this plugin because there are several plugins that handles the Foursquare API already, but none of them are taking care of the OAuth token aquisition.
+I created this plugin because there are several plugins that handles the Foursquare API already, but none of them are taking care of the OAuth token acquisition.
 
 **Grails Foursquare Plugin** provides the following Grails artefacts:
 


### PR DESCRIPTION
@eduardm, I've corrected a typographical error in the documentation of the [fsq](https://github.com/eduardm/fsq) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
